### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SourceBot Website
+[![Run on Repl.it](https://repl.it/badge/github/Splatboy-Dev/GPDB.net)](https://repl.it/github/Splatboy-Dev/GPDB.net)
 <div align="center">
 <img src="https://i.imgur.com/qwt4PFB.png" align="center" alt="Logo">
 <br><br>


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).